### PR TITLE
Fixed a bug in data-backend-url, Code Style and basic general Extension support

### DIFF
--- a/jooag_shariff.php
+++ b/jooag_shariff.php
@@ -76,7 +76,7 @@ class PlgSystemJooag_Shariff extends JPlugin
 			}
 		}
 
-		if ($context == 'sharrif.general' && $app->isSite())
+		if ($context == 'shariff.general' && $app->isSite())
 		{
 			$stringCount = 0;
 

--- a/jooag_shariff.php
+++ b/jooag_shariff.php
@@ -1,21 +1,28 @@
 <?php
 /**
- * @package    JooAg_Shariff
- *
- * @author     Joomla Agentur <info@joomla-agentur.de>
- * @copyright  Copyright (c) 2009 - 2015 Joomla-Agentur All rights reserved.
- * @license    GNU General Public License version 2 or later;
+ * @package     JooAg_Shariff
+ * @author      Joomla Agentur <info@joomla-agentur.de>
+ * @copyright   Copyright (c) 2009 - 2015 Joomla-Agentur All rights reserved.
+ * @license     GNU General Public License version 2 || later;
  * @description A small Plugin to share Social Links without compromising their privacy!
  **/
-defined('_JEXEC') or die;
+
+defined('_JEXEC') || die;
 
 /**
- * Class PlgContentJooag_Shariff
+ * Class {
  *
  * @since  1.0.0
- **/
-class plgSystemJooag_Shariff extends JPlugin
+ */
+class PlgSystemJooag_Shariff extends JPlugin
 {
+	/**
+	 * The plugin context
+	 *
+	 * @var    string
+	 */
+	protected $context = null;
+
 	/**
 	 * Display the buttons before the article
 	 *
@@ -25,16 +32,18 @@ class plgSystemJooag_Shariff extends JPlugin
 	 * @param   integer  $page      Optional page number. Unused. Defaults to zero.
 	 *
 	 * @return  string
-	 **/
+	 */
 	public function onContentBeforeDisplay($context, &$article, &$params, $page = 0)
-	{		
+	{
 		$app = JFactory::getApplication();
 
-		if($context == 'com_content.article' and $this->params->get('position') == 1 and $app->isSite())
+		$this->context = $context;
+
+		if ($context == 'com_content.article' && $this->params->get('position') == 1 && $app->isSite())
 		{
 			$article->introtext = str_replace('{noshariff}', '', $article->introtext, $stringCount);
-	
-			if($stringCount == 0)
+
+			if ($stringCount == 0)
 			{
 				return $this->getOutputPosition($article, $config = array());
 			}
@@ -50,16 +59,28 @@ class plgSystemJooag_Shariff extends JPlugin
 	 * @param   integer  $page      Optional page number. Unused. Defaults to zero.
 	 *
 	 * @return  string
-	 **/
+	 */
 	public function onContentAfterDisplay($context, &$article, &$params, $page = 0)
 	{
 		$app = JFactory::getApplication();
-			
-		if($context == 'com_content.article' and $this->params->get('position') == 2 and $app->isSite())
+
+		$this->context = $context;
+
+		if ($context == 'com_content.article' && $this->params->get('position') == 2 && $app->isSite())
 		{
 			$article->introtext = str_replace('{noshariff}', '', $article->introtext, $stringCount);
-			
-			if($stringCount == 0)
+
+			if ($stringCount == 0)
+			{
+				return $this->getOutputPosition($article, $config = array());
+			}
+		}
+
+		if ($context == 'com_matukio.event' && $app->isSite())
+		{
+			$article->description = str_replace('{noshariff}', '', $article->description, $stringCount);
+
+			if ($stringCount == 0)
 			{
 				return $this->getOutputPosition($article, $config = array());
 			}
@@ -68,29 +89,39 @@ class plgSystemJooag_Shariff extends JPlugin
 
 	/**
 	 * Place shariff in your aticles and modules via {shariff} shorttag
-	 **/
+	 *
+	 * @param   string   $context   The context of the content being passed to the plugin.
+	 * @param   mixed    &$article  An object with a "text" property
+	 * @param   mixed    &$params   Additional parameters. See {@see PlgContentContent()}.
+	 * @param   integer  $page      Optional page number. Unused. Defaults to zero.
+	 *
+	 * @return  void
+	 */
 	public function onContentPrepare($context, &$article, &$params, $page = 0)
 	{
 		$app = JFactory::getApplication();
-		
-		if($context == 'mod_custom.content' and preg_match_all('/{shariff\ ([^}]+)\}|\{shariff\}/', $article->text, $matches) and $app->isSite())
+
+		$this->context = $context;
+
+		if ($context == 'mod_custom.content' && preg_match_all('/{shariff\ ([^}]+)\}|\{shariff\}/', $article->text, $matches) && $app->isSite())
 		{
-			$params = explode(' ', trim($matches[0][0],'}'));
-			$config = array ();
+			$params = explode(' ', trim($matches[0][0], '}'));
+			$config = array();
 
 			foreach ($params as $key => $item)
 			{
-				if($key != 0)
+				if ($key != 0)
 				{
 					list($k, $v) = explode("=", $item);
-					$config[ $k ] = $v;
+					$config[$k] = $v;
 				}
 			}
 
 			$article->text = str_replace($matches[0][0], $this->getOutputPosition($article, $config), $article->text);
 		}
-		
-		if	($context == 'mod_articles_news.content' and ($this->params->get('position') == 1 or $this->params->get('position') == 2)){
+
+		if ($context == 'mod_articles_news.content' && ($this->params->get('position') == 1 || $this->params->get('position') == 2))
+		{
 			$article->text .= '{noshariff}';
 		}
 	}
@@ -98,115 +129,134 @@ class plgSystemJooag_Shariff extends JPlugin
 	/**
 	 * appends the required scripts to the documents and returns the markup
 	 *
-	 * @param   mixed    &$article  An object with a "text" property
+	 * @param   mixed  $article  - An object with a "text" property
+	 * @param   array  $config   - Config
 	 *
-	 * @return string
-	 **/
+	 * @return  void|string
+	 */
 	public function getOutputPosition($article, $config)
 	{
-		$catIds = (array)$this->params->get('showbycategory');
-		$menuIds = (array)$this->params->get('showbymenu');
-		$app = JFactory::getApplication();
-		$menu = $app->getMenu()->getActive();
-		
+		$catIds  = (array) $this->params->get('showbycategory');
+		$menuIds = (array) $this->params->get('showbymenu');
+		$app     = JFactory::getApplication();
+		$menu    = $app->getMenu()->getActive();
+
 		if (is_object($menu))
 		{
-		  $actualMenuId = $menu->id;
+			$actualMenuId = $menu->id;
 		}
 		else
 		{
-		  $actualMenuId = $app->input->getInt('Itemid', 0);
+			$actualMenuId = $app->input->getInt('Itemid', 0);
 		}
 
 		$view = 0;
 
-		if($this->params->get('wheretoshow') == 3){
+		if ($this->params->get('wheretoshow') == 3)
+		{
 			$view = 1;
 		}
 
-		if ((isset($article->catid) and in_array($article->catid, $catIds)) or in_array($actualMenuId, $menuIds))
+		if ((isset($article->catid) && in_array($article->catid, $catIds)) || in_array($actualMenuId, $menuIds))
 		{
-			if($this->params->get('wheretoshow') == 2){
+			if ($this->params->get('wheretoshow') == 2)
+			{
 				$view = 1;
 			}
 
-			if($this->params->get('wheretoshow') == 3){
+			if ($this->params->get('wheretoshow') == 3)
+			{
 				$view = 0;
 			}
 		}
 
-		if($view == 1 or $this->params->get('wheretoshow') == 1){
+		if ($view == 1 || $this->params->get('wheretoshow') == 1)
+		{
 			return $this->getOutput($config);
 		}
 	}
 
 	/**
 	 * Shariff output generation
-	 **/
+	 *
+	 * @param   array  $config  - Config
+	 *
+	 * @return  string
+	 */
 	public function getOutput($config)
 	{
 		$doc = JFactory::getDocument();
+
 		JHtml::_('jquery.framework');
-		$doc->addStyleSheet(JURI::root().'media/plg_jooag_shariff/css/'.$this->params->get('shariffcss'));
-		$doc->addScript(JURI::root().'media/plg_jooag_shariff/js/'.$this->params->get('shariffjs'));
+		$doc->addStyleSheet(JURI::root() . 'media/plg_jooag_shariff/css/' . $this->params->get('shariffcss'));
+		$doc->addScript(JURI::root() . 'media/plg_jooag_shariff/js/' . $this->params->get('shariffjs'));
 		$doc->addScriptDeclaration('jQuery(document).ready(function() {var buttonsContainer = jQuery(".shariff");new Shariff(buttonsContainer);});');
 
-		//Cache Folder
+		// Cache Folder
 		jimport('joomla.filesystem.folder');
-		if(!JFolder::exists(JPATH_SITE.'/cache/plg_jooag_shariff') and $this->params->get('data_backend_url')){
-			JFolder::create(JPATH_SITE.'/cache/plg_jooag_shariff', 0755);
+
+		if (!JFolder::exists(JPATH_SITE . '/cache/plg_jooag_shariff') && $this->params->get('data_backend_url'))
+		{
+			JFolder::create(JPATH_SITE . '/cache/plg_jooag_shariff', 0755);
 		}
-		
-		$html  = '<div class="shariff"';
-		$html .= ($this->params->get('data_backend_url')) ? ' data-backend-url="/plugins/system/jooag_shariff/backend/"' : '';
-		$html .= ' data-lang="'.explode("-", JFactory::getLanguage()->getTag())[0].'"';
-		$html .= ($this->params->get('data_mail_url')) ? ' data-mail-url="mailto:'.$this->params->get('data_mail_url').'"' : '';
-		$html .= (array_key_exists('orientation', $config)) ? ' data-orientation="'.$config['orientation'].'"' : ' data-orientation="'.$this->params->get('data_orientation').'"';
-		$html .= ' data-services="'.htmlspecialchars(json_encode(array_map('strtolower', (array)json_decode($this->params->get('data_services'))->services))).'"';
-		$html .= (array_key_exists('theme', $config)) ? ' data-theme="'.$config['theme'].'"' : ' data-theme="'.$this->params->get('data_theme').'"';
-		$html .= ' data-url="'.JURI::getInstance()->toString().'"';
-		
-		if (($id = (int)$this->params->get('data_info_url')))
+
+		$html = '<div class="shariff"';
+		$html .= ($this->params->get('data_backend_url')) ? ' data-backend-url="' . JURI::root() . '/plugins/system/jooag_shariff/backend/"' : '';
+		$html .= ' data-lang="' . explode("-", JFactory::getLanguage()->getTag())[0] . '"';
+		$html .= ($this->params->get('data_mail_url')) ? ' data-mail-url="mailto:' . $this->params->get('data_mail_url') . '"' : '';
+		$html .= (array_key_exists('orientation', $config)) ? ' data-orientation="' . $config['orientation'] . '"' : ' data-orientation="' . $this->params->get('data_orientation') . '"';
+
+		$html .= ' data-services="' . htmlspecialchars(json_encode(array_map('strtolower', (array) json_decode($this->params->get('data_services'))->services))) . '"';
+		$html .= (array_key_exists('theme', $config)) ? ' data-theme="' . $config['theme'] . '"' : ' data-theme="' . $this->params->get('data_theme') . '"';
+		$html .= ' data-url="' . JURI::getInstance()->toString() . '"';
+
+		if (($id = (int) $this->params->get('data_info_url')) && $this->context == 'com_content.article')
 		{
 			jimport('joomla.database.table');
-			$item =	JTable::getInstance("content");
+			$item = JTable::getInstance("content");
 			$item->load($this->params->get('data_info_url'));
 			require_once JPATH_SITE . '/components/com_content/helpers/route.php';
 			$link = JRoute::_(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language));
-			$html .= ' data-info-url="'.$link.'"';
+			$html .= ' data-info-url="' . $link . '"';
 		}
-		
+
 		$html .= '></div>';
+
 		return $html;
 	}
 
 	/**
 	 * Generator for shariff.json if the is saved
 	 *
+	 * @param   string  $context  - The context passed to the plugin.
+	 * @param   JTable  $table    - The JTable object
+	 * @param   bool    $isNew    - Is the entry new?
+	 *
 	 * @return void
-	 **/
+	 */
 	public function onExtensionBeforeSave($context, $table, $isNew)
 	{
-		if($table->name == 'PLG_JOOAG_SHARIFF')
+		if ($table->name == 'PLG_JOOAG_SHARIFF')
 		{
-			$params = json_decode($table->params);
-			$data->domain = JURI::getInstance()->getHost();
-			$data->services = array_diff(json_decode($params->data_services)->services, array('AddThis','Whatsapp','Mail','Info','Tumblr','Flattr','Diaspora'));
+			$params         = json_decode($table->params);
+			$data->domain   = JURI::getInstance()->getHost();
+			$data->services = array_diff(json_decode($params->data_services)->services, array('AddThis', 'Whatsapp', 'Mail', 'Info', 'Tumblr', 'Flattr', 'Diaspora'));
 
-			if($params->fb_app_id and $params->fb_secret)
+			if ($params->fb_app_id && $params->fb_secret)
 			{
 				$data->Facebook->app_id = $params->fb_app_id;
 				$data->Facebook->secret = $params->fb_secret;
 			}
 
-			$data->cache->cacheDir = JPATH_SITE.'/cache/plg_jooag_shariff';
-			$data->cache->ttl = $params->cache_time;
+			$data->cache->cacheDir = JPATH_SITE . '/cache/plg_jooag_shariff';
+			$data->cache->ttl      = $params->cache_time;
 
-			if($params->cache == 1)
+			if ($params->cache == 1)
 			{
 				$data->cache->adapter = $params->cache_handler;
 
-				if($params->cache_handler == 'file'){
+				if ($params->cache_handler == 'file')
+				{
 					$data->cache->adapter = 'filesystem';
 				}
 			}

--- a/jooag_shariff.php
+++ b/jooag_shariff.php
@@ -78,7 +78,13 @@ class PlgSystemJooag_Shariff extends JPlugin
 
 		if ($context == 'sharrif.general' && $app->isSite())
 		{
-			$article->description = str_replace('{noshariff}', '', $article->description, $stringCount);
+			$stringCount = 0;
+
+			// Way to supply option to disable shariff
+			if (isset($article->description))
+			{
+				$article->description = str_replace('{noshariff}', '', $article->description, $stringCount);
+			}
 
 			if ($stringCount == 0)
 			{

--- a/jooag_shariff.php
+++ b/jooag_shariff.php
@@ -7,10 +7,10 @@
  * @description A small Plugin to share Social Links without compromising their privacy!
  **/
 
-defined('_JEXEC') || die;
+defined('_JEXEC') or die;
 
 /**
- * Class {
+ * Class PlgSystemJooag_Shariff
  *
  * @since  1.0.0
  */
@@ -76,7 +76,7 @@ class PlgSystemJooag_Shariff extends JPlugin
 			}
 		}
 
-		if ($context == 'com_matukio.event' && $app->isSite())
+		if ($context == 'sharrif.general' && $app->isSite())
 		{
 			$article->description = str_replace('{noshariff}', '', $article->description, $stringCount);
 
@@ -239,6 +239,7 @@ class PlgSystemJooag_Shariff extends JPlugin
 		if ($table->name == 'PLG_JOOAG_SHARIFF')
 		{
 			$params         = json_decode($table->params);
+			$data = new stdClass;
 			$data->domain   = JURI::getInstance()->getHost();
 			$data->services = array_diff(json_decode($params->data_services)->services, array('AddThis', 'Whatsapp', 'Mail', 'Info', 'Tumblr', 'Flattr', 'Diaspora'));
 


### PR DESCRIPTION
Tried to clean up the plugin code (now is more or less Joomla code style valid). 

More important fixed a bug (missing JURI::root() in the data-backend-url). If Joomla is installed in a subfolder, this is causing the plugin backend (vendor folder) loading to fail. 

Additionally added support for other extensions (really basic only, they just need to call onContentPrepare with "sharrif.general"). 

For example:

$dispatcher = JDispatcher::getInstance();
JPluginHelper::importPlugin('content');
$results = $dispatcher->trigger('onContentAfterDisplay', array('shariff.general', &$event, &$params, 0));
$sharrif_content = trim(implode("\n", $results));

When i have some time i am going to contribute more..

Sorry that this PR got so big, just copied it from my working project..
