### PR TITLE
fix jooag_shariff.xml update server definition.

### DIFF
--- a/jooag_shariff.xml
+++ b/jooag_shariff.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="4.0" type="plugin" method="upgrade" group="system">
+<extension version="3.8" type="plugin" method="upgrade" group="system">
 	<name>PLG_JOOAG_SHARIFF</name>
 	<author>Ufuk Avcu</author>
 	<creationDate>29.04.2018</creationDate>
@@ -148,6 +148,6 @@
 		</fields>
 	</config>
 	<updateservers>
-		<server type="extension" priority="2" name="JooAg Shariff Update">https://joomla-agentur.de/index.php?option=com_ars&view=update&task=stream&format=xml&id=1</server>
+		<server type="extension" priority="2" name="JooAg Shariff Update"><![CDATA[https://joomla-agentur.de/index.php?option=com_ars&view=update&task=stream&format=xml&id=1]]></server>
 	</updateservers>
 </extension>


### PR DESCRIPTION
You need to throw the update server into a CDATA else joomla can't read the file and throws errors.

I have also corrected the version attribute as this indicates the minimal joomla version (does not have any affect at all but that is the general rule for that field)